### PR TITLE
remove the Advanced() method from Index

### DIFF
--- a/index.go
+++ b/index.go
@@ -19,8 +19,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-
-	"github.com/blevesearch/bleve_index_api/store"
 )
 
 var reflectStaticSizeTermFieldDoc int
@@ -52,8 +50,6 @@ type Index interface {
 
 	Stats() json.Marshaler
 	StatsMap() map[string]interface{}
-
-	Advanced() (store.KVStore, error)
 }
 
 type DocumentFieldTermVisitor func(field string, term []byte)


### PR DESCRIPTION
this method is specific to index implementations that have
an underlying K/V store, so it does not belong on an interface
for all indexes.