### PR TITLE
remove dump methods from index reader

### DIFF
--- a/index.go
+++ b/index.go
@@ -83,10 +83,6 @@ type IndexReader interface {
 	ExternalID(id IndexInternalID) (string, error)
 	InternalID(id string) (IndexInternalID, error)
 
-	DumpAll() chan interface{}
-	DumpDoc(id string) chan interface{}
-	DumpFields() chan interface{}
-
 	Close() error
 }
 


### PR DESCRIPTION
these methods are not easily supported by all indexes
and in practice were only implemented by the
upsidedown index.

different index implementations will likely have different
ways of dumping their contents, which cannot fit some
generic methods.  based on this, it seems reasonable that when
debugging/dumping contents, you first type assert and use
methods specific to that implementation.