### PR TITLE
Introducing new GeoShapeField interface

### DIFF
--- a/document.go
+++ b/document.go
@@ -77,6 +77,10 @@ type GeoPointField interface {
 	Lat() (float64, error)
 }
 
+type GeoShapeField interface {
+	GeoShape() (GeoJSON, error)
+}
+
 // TokenizableSpatialField is an optional interface for fields that
 // supports pluggable custom hierarchial spatial token generation.
 type TokenizableSpatialField interface {

--- a/spatial_plugin.go
+++ b/spatial_plugin.go
@@ -41,4 +41,7 @@ type GeoJSON interface {
 
 	// Checks whether the given shape resides within the current shape.
 	Contains(GeoJSON) (bool, error)
+
+	// Value returns the byte value for the shape.
+	Value() ([]byte, error)
 }


### PR DESCRIPTION
This interface implementation helps to retrieve the
original value of the spatial field during store
field value fetch use case.

Adding a Value() ([]byte, error) method to GeoJSON
interface.