### PR TITLE
Introducing a BytesRead field in TermFieldDoc struct

### DIFF
--- a/index.go
+++ b/index.go
@@ -123,11 +123,12 @@ func (id IndexInternalID) Compare(other IndexInternalID) int {
 }
 
 type TermFieldDoc struct {
-	Term    string
-	ID      IndexInternalID
-	Freq    uint64
-	Norm    float64
-	Vectors []*TermFieldVector
+	Term      string
+	ID        IndexInternalID
+	Freq      uint64
+	Norm      float64
+	Vectors   []*TermFieldVector
+	BytesRead uint64
 }
 
 func (tfd *TermFieldDoc) Size() int {


### PR DESCRIPTION
The main reason for introducing this change is to ensure that we don't track and update the IO stats at a per hit level, which due to heavy contention causes a significant regression (the corresponding bleve issue: https://github.com/blevesearch/bleve/issues/1731). 

The changes essentially allow us to track the bytes read information and aggregate this value from all the hits at the collector level.

The corresponding bleve PR: https://github.com/blevesearch/bleve/pull/1738