### PR TITLE
[Synonym Filter] Document Interface Change

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -14,20 +14,26 @@
 
 package index
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type BatchCallback func(error)
 
 type Batch struct {
 	IndexOps          map[string]Document
 	InternalOps       map[string][]byte
+	SynOps            map[string]Document
+	SynonymAnalyzers  map[string]interface{}
 	persistedCallback BatchCallback
 }
 
 func NewBatch() *Batch {
 	return &Batch{
-		IndexOps:    make(map[string]Document),
-		InternalOps: make(map[string][]byte),
+		IndexOps:         make(map[string]Document),
+		SynOps:           make(map[string]Document),
+		InternalOps:      make(map[string][]byte),
+		SynonymAnalyzers: make(map[string]interface{}),
 	}
 }
 
@@ -43,6 +49,10 @@ func (b *Batch) SetInternal(key, val []byte) {
 	b.InternalOps[string(key)] = val
 }
 
+func (b *Batch) SetSynonymAnalyzer(key string, val interface{}) {
+	b.SynonymAnalyzers[key] = val
+}
+
 func (b *Batch) DeleteInternal(key []byte) {
 	b.InternalOps[string(key)] = nil
 }
@@ -53,6 +63,10 @@ func (b *Batch) SetPersistedCallback(f BatchCallback) {
 
 func (b *Batch) PersistedCallback() BatchCallback {
 	return b.persistedCallback
+}
+
+func (b *Batch) UpdateSynonym(doc Document) {
+	b.SynOps[doc.ID()] = doc
 }
 
 func (b *Batch) String() string {

--- a/document.go
+++ b/document.go
@@ -19,8 +19,6 @@ import (
 	"reflect"
 	"sync"
 	"time"
-
-	"github.com/blevesearch/bleve/v2/size"
 )
 
 // A synonym document is a json object with the following fields:
@@ -41,7 +39,8 @@ type SynonymDefinition struct {
 
 func (s *SynonymDefinition) Size() int {
 	var sd SynonymDefinition
-	sizeInBytes := len(s.MappingType) + int(reflect.TypeOf(sd).Size()) + size.SizeOfPtr
+	var ptr *int
+	sizeInBytes := len(s.MappingType) + int(reflect.TypeOf(sd).Size()) + int(reflect.TypeOf(ptr).Size())
 	for _, entry := range s.Input {
 		sizeInBytes += len(entry)
 	}

--- a/document.go
+++ b/document.go
@@ -29,6 +29,7 @@ type Document interface {
 	AddIDField()
 
 	StoredFieldsBytes() uint64
+	SynonymInfo() interface{}
 }
 
 type FieldVisitor func(Field)


### PR DESCRIPTION
Add a non-breaking method to the document interface which would aid the indexer in differentiating between the normal documents(retrieved from buckets) and the synonym documents in a Batch.