### PR TITLE
MB-59421: export min and max allowed values of vector dims

### DIFF
--- a/vector.go
+++ b/vector.go
@@ -27,6 +27,12 @@ type VectorField interface {
 
 // -----------------------------------------------------------------------------
 
+// Min and Max allowed dimensions for a vector field
+const (
+	MinVectorDims = 1
+	MaxVectorDims = 2048
+)
+
 const (
 	EuclideanDistance = "l2_norm"
 


### PR DESCRIPTION
Merge before: https://github.com/blevesearch/bleve/pull/1903