### PR TITLE
MB-60943 - Add option for memory-optimised vector indexes.

### DIFF
--- a/vector.go
+++ b/vector.go
@@ -53,6 +53,7 @@ var SupportedSimilarityMetrics = map[string]struct{}{
 const (
 	IndexOptimizedForRecall  = "recall"
 	IndexOptimizedForLatency = "latency"
+	IndexOptimizedForMemory  = "memory"
 )
 
 const DefaultIndexOptimization = IndexOptimizedForRecall
@@ -60,10 +61,12 @@ const DefaultIndexOptimization = IndexOptimizedForRecall
 var SupportedVectorIndexOptimizations = map[string]int{
 	IndexOptimizedForRecall:  0,
 	IndexOptimizedForLatency: 1,
+	IndexOptimizedForMemory:  2,
 }
 
 // Reverse maps vector index optimizations': int -> string
 var VectorIndexOptimizationsReverseLookup = map[int]string{
 	0: IndexOptimizedForRecall,
 	1: IndexOptimizedForLatency,
+	2: IndexOptimizedForMemory,
 }


### PR DESCRIPTION
This PR adds an option to optimise for memory to the supported vector index optimisations.