### PR TITLE
MB-61985: Support triggering Scorch events externally

### DIFF
--- a/index.go
+++ b/index.go
@@ -57,18 +57,12 @@ type CopyIndex interface {
 	CopyReader() CopyReader
 }
 
-// EventKind represents an event code that can be used to execute external callbacks
-// for various events in the index.
-type EventKind int
-
-// EventKindIndex is a type of event that is fired when a new document is added to the index.
-var EventKindIndex = EventKind(1)
-
 // EventIndex is an optional interface for exposing the support for firing event
 // callbacks for various events in the index.
 type EventIndex interface {
-	// FireEvent is used to fire an event callback for the specified event kind.
-	FireEvent(event EventKind)
+	// FireIndexEvent is used to fire an event callback when Index() is called,
+	// to notify the caller that a document has been added to the index.
+	FireIndexEvent()
 }
 
 type IndexReader interface {

--- a/index.go
+++ b/index.go
@@ -56,12 +56,19 @@ type CopyIndex interface {
 	// to handle necessary bookkeeping, instead of using the regular IndexReader.
 	CopyReader() CopyReader
 }
+
+// EventKind represents an event code that can be used to execute external callbacks
+// for various events in the index.
+type EventKind int
+
+// EventKindIndex is a type of event that is fired when a new document is added to the index.
+var EventKindIndex = EventKind(1)
+
+// EventIndex is an optional interface for exposing the support for firing event
+// callbacks for various events in the index.
 type EventIndex interface {
-	Index
-
-	OnIndexStart()
-
-	OnIndex()
+	// FireEvent is used to fire an event callback for the specified event kind.
+	FireEvent(event EventKind)
 }
 
 type IndexReader interface {

--- a/index.go
+++ b/index.go
@@ -56,6 +56,13 @@ type CopyIndex interface {
 	// to handle necessary bookkeeping, instead of using the regular IndexReader.
 	CopyReader() CopyReader
 }
+type EventIndex interface {
+	Index
+
+	OnIndexStart()
+
+	OnIndex()
+}
 
 type IndexReader interface {
 	TermFieldReader(ctx context.Context, term []byte, field string, includeFreq, includeNorm, includeTermVectors bool) (TermFieldReader, error)


### PR DESCRIPTION
- Add an optional method for Index implementations to support, which would allow firing scorch events externally.