### PR TITLE
MB-62230 - Pre-Filtering Support for kNN

### DIFF
--- a/vector_index.go
+++ b/vector_index.go
@@ -48,8 +48,9 @@ type VectorReader interface {
 }
 
 type VectorIndexReader interface {
-	VectorReader(ctx context.Context, vector []float32, field string, k int64, searchParams json.RawMessage) (
-		VectorReader, error)
+	VectorReader(ctx context.Context, vector []float32, field string, k int64,
+		searchParams json.RawMessage, filterIDs []IndexInternalID,
+		requireFiltering bool) (VectorReader, error)
 }
 
 type VectorDoc struct {

--- a/vector_index.go
+++ b/vector_index.go
@@ -49,8 +49,10 @@ type VectorReader interface {
 
 type VectorIndexReader interface {
 	VectorReader(ctx context.Context, vector []float32, field string, k int64,
-		searchParams json.RawMessage, filterIDs []IndexInternalID,
-		requireFiltering bool) (VectorReader, error)
+		searchParams json.RawMessage) (VectorReader, error)
+
+	VectorReaderWithFilter(ctx context.Context, vector []float32, field string, k int64,
+		searchParams json.RawMessage, filterIDs []IndexInternalID) (VectorReader, error)
 }
 
 type VectorDoc struct {


### PR DESCRIPTION
Adds VectorReaderWithFilter to include pre-filtering related params like documents eligible for kNN based on the filter query.