### PR TITLE
MB-57888: Index Update

### DIFF
--- a/index.go
+++ b/index.go
@@ -65,6 +65,18 @@ type EventIndex interface {
 	FireIndexEvent()
 }
 
+type FieldInfo struct {
+	All       bool
+	Store     bool
+	Index     bool
+	DocValues bool
+}
+
+type UpdateIndex interface {
+	Index
+	UpdateFields(fieldInfo map[string]*FieldInfo, updatedMapping []byte) error
+}
+
 type IndexReader interface {
 	TermFieldReader(ctx context.Context, term []byte, field string, includeFreq, includeNorm, includeTermVectors bool) (TermFieldReader, error)
 

--- a/index.go
+++ b/index.go
@@ -65,8 +65,8 @@ type EventIndex interface {
 	FireIndexEvent()
 }
 
-type FieldInfo struct {
-	All       bool
+type UpdateFieldInfo struct {
+	Deleted   bool
 	Store     bool
 	Index     bool
 	DocValues bool
@@ -74,7 +74,7 @@ type FieldInfo struct {
 
 type UpdateIndex interface {
 	Index
-	UpdateFields(fieldInfo map[string]*FieldInfo, updatedMapping []byte) error
+	UpdateFields(fieldInfo map[string]*UpdateFieldInfo, updatedMapping []byte) error
 }
 
 type IndexReader interface {


### PR DESCRIPTION
 - Added fieldInfo which stores what bits of each zapx field is supposed to be deleted
 - Extending the index interface to include an api that updates the bolt db metadata