### PR TITLE
MB-65554: Add Searchable method to Document interface

### DIFF
--- a/document.go
+++ b/document.go
@@ -32,6 +32,8 @@ type Document interface {
 	AddIDField()
 
 	StoredFieldsBytes() uint64
+
+	Searchable() bool
 }
 
 type FieldVisitor func(Field)


### PR DESCRIPTION
- Adds a `Searchable()` method to the `Document` interface which indicates where the document
  is searchable within the index. (i.e. whether the document's fields can be queried upon by 
  a search request.)