### PR TITLE
MB-65473: Refactor and Optimize Pre-Filtered Vector Search

### DIFF
--- a/index.go
+++ b/index.go
@@ -346,3 +346,11 @@ type ThesaurusReader interface {
 	// start with the given prefix.
 	ThesaurusKeysPrefix(name string, termPrefix []byte) (ThesaurusKeys, error)
 }
+
+// EligibleDocumentSelector selects documents based on specific eligibility criteria.
+// It can be extended with additional methods for filtering and retrieval.
+type EligibleDocumentSelector interface {
+	// EligibleDocNums returns a list of document numbers that are eligible within the specified segment.
+	// segmentID identifies the segment for which eligible document numbers are retrieved.
+	SegmentEligibleDocs(segmentID int) []uint64
+}

--- a/vector_index.go
+++ b/vector_index.go
@@ -49,10 +49,8 @@ type VectorReader interface {
 
 type VectorIndexReader interface {
 	VectorReader(ctx context.Context, vector []float32, field string, k int64,
-		searchParams json.RawMessage) (VectorReader, error)
-
-	VectorReaderWithFilter(ctx context.Context, vector []float32, field string, k int64,
-		searchParams json.RawMessage, filterIDs []IndexInternalID) (VectorReader, error)
+		searchParams json.RawMessage, selector EligibleDocumentSelector) (
+		VectorReader, error)
 }
 
 type VectorDoc struct {


### PR DESCRIPTION
- Add an interface `EligibleDocumentSelector` to allow for more flexible document selection.
- Refactored redundant interfaces.