### PR TITLE
MB-57888: Index Update

### DIFF
--- a/index.go
+++ b/index.go
@@ -65,6 +65,19 @@ type EventIndex interface {
 	FireIndexEvent()
 }
 
+type UpdateFieldInfo struct {
+	Deleted   bool
+	Store     bool
+	Index     bool
+	DocValues bool
+}
+
+type UpdateIndex interface {
+	Index
+	UpdateFields(fieldInfo map[string]*UpdateFieldInfo, updatedMapping []byte) error
+	OpenMeta() error
+}
+
 type IndexReader interface {
 	TermFieldReader(ctx context.Context, term []byte, field string, includeFreq, includeNorm, includeTermVectors bool) (TermFieldReader, error)
 


### PR DESCRIPTION
- Added UpdateFieldInfo which tracks which parts of the zapx fields have
been deleted during an update
 - Added a new index interface which implements two new functions
 - OpenMeta opens only the index metadata allowing us to read index definition
without starting the index
 - UpdateFields allows us to write to meta all of the updated fields info while
the index is closed

Any updates to the index needs to be done while the index is closed. This is to ensure that once the index is live, the maps will not be updated under any circumstances. Hot reloads will require mapping which we are trying to avoid as these maps are used during query paths.