### PR TITLE
MB-65473: Extend VectorReader interface to get the EligibleDocumentSelector

### DIFF
--- a/index.go
+++ b/index.go
@@ -347,10 +347,15 @@ type ThesaurusReader interface {
 	ThesaurusKeysPrefix(name string, termPrefix []byte) (ThesaurusKeys, error)
 }
 
-// EligibleDocumentSelector selects documents based on specific eligibility criteria.
+// EligibleDocumentSelector filters documents based on specific eligibility criteria.
 // It can be extended with additional methods for filtering and retrieval.
 type EligibleDocumentSelector interface {
-	// EligibleDocNums returns a list of document numbers that are eligible within the specified segment.
-	// segmentID identifies the segment for which eligible document numbers are retrieved.
+	// AddEligibleDocumentMatch marks a document as eligible for selection.
+	// id is the internal identifier of the document to be added.
+	AddEligibleDocumentMatch(id IndexInternalID) error
+
+	// SegmentEligibleDocs returns a list of eligible document IDs within a given segment.
+	// segmentID identifies the segment for which eligible documents are retrieved.
+	// This must be called after all eligible documents have been added.
 	SegmentEligibleDocs(segmentID int) []uint64
 }

--- a/vector_index.go
+++ b/vector_index.go
@@ -47,7 +47,18 @@ type VectorReader interface {
 	Size() int
 }
 
+// VectorIndexReader is an index reader that can retrieve similar vectors from a vector-based index.
 type VectorIndexReader interface {
+	// NewEligibleDocumentSelector returns an instance of an eligible document selector.
+	// This selector filters documents for KNN search based on a pre-filter query.
+	NewEligibleDocumentSelector() EligibleDocumentSelector
+
+	// VectorReader creates a new vector reader for performing KNN search.
+	// - vector: the query vector
+	// - field: the field to search in
+	// - k: the number of similar vectors to return
+	// - searchParams: additional search parameters
+	// - selector: an eligible document selector to filter documents before KNN search
 	VectorReader(ctx context.Context, vector []float32, field string, k int64,
 		searchParams json.RawMessage, selector EligibleDocumentSelector) (
 		VectorReader, error)


### PR DESCRIPTION
- Refactor interface as per https://github.com/blevesearch/bleve/pull/2169#discussion_r2014048821