### PR TITLE
MB-66295: Introduce BM25Reader interface  

### DIFF
--- a/index.go
+++ b/index.go
@@ -74,6 +74,7 @@ type IndexReader interface {
 
 	DocIDReaderOnly(ids []string) (DocIDReader, error)
 
+	FieldCardinality(field string) (int, error)
 	FieldDict(field string) (FieldDict, error)
 
 	// FieldDictRange is currently defined to include the start and end terms

--- a/index.go
+++ b/index.go
@@ -74,7 +74,6 @@ type IndexReader interface {
 
 	DocIDReaderOnly(ids []string) (DocIDReader, error)
 
-	FieldCardinality(field string) (int, error)
 	FieldDict(field string) (FieldDict, error)
 
 	// FieldDictRange is currently defined to include the start and end terms
@@ -95,6 +94,11 @@ type IndexReader interface {
 	InternalID(id string) (IndexInternalID, error)
 
 	Close() error
+}
+
+type BM25Reader interface {
+	IndexReader
+	FieldCardinality(field string) (int, error)
 }
 
 // CopyReader is an extended index reader for backup or online copy operations, replacing the regular index reader.


### PR DESCRIPTION
- this is crucial for caching at the snapshot level which can be reused across queries