### PR TITLE
Minor changes to index ID APIs

### DIFF
--- a/index.go
+++ b/index.go
@@ -203,8 +203,9 @@ func NewIndexInternalID(buf []byte, in uint64) IndexInternalID {
 			buf = make([]byte, 8)
 		}
 	}
-	binary.BigEndian.PutUint64(buf, in)
-	return buf
+	id := IndexInternalID(buf)
+	id.SetValue(in)
+	return id
 }
 
 // NewIndexInternalIDFrom creates a new IndexInternalID by copying from `other`, reusing `buf` when possible.
@@ -228,8 +229,8 @@ func (id IndexInternalID) Value() uint64 {
 	return binary.BigEndian.Uint64(id)
 }
 
-// Reset replaces the encoded uint64 value in the IndexInternalID with a new value.
-func (id IndexInternalID) Reset(in uint64) {
+// SetValue overwrites the encoded uint64 value in the IndexInternalID in place.
+func (id IndexInternalID) SetValue(in uint64) {
 	binary.BigEndian.PutUint64(id, in)
 }
 

--- a/index.go
+++ b/index.go
@@ -15,6 +15,7 @@
 package index
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"reflect"
@@ -219,14 +220,7 @@ func (id IndexInternalID) Equals(other IndexInternalID) bool {
 
 // Compare compares two IndexInternalID values, inherently comparing the encoded uint64 values.
 func (id IndexInternalID) Compare(other IndexInternalID) int {
-	idVal := id.Value()
-	otherVal := other.Value()
-	if idVal < otherVal {
-		return -1
-	} else if idVal > otherVal {
-		return 1
-	}
-	return 0
+	return bytes.Compare(id, other)
 }
 
 // Value returns the uint64 value encoded in the IndexInternalID.

--- a/index.go
+++ b/index.go
@@ -234,6 +234,11 @@ func (id IndexInternalID) Value() uint64 {
 	return binary.BigEndian.Uint64(id)
 }
 
+// Reset replaces the encoded uint64 value in the IndexInternalID with a new value.
+func (id IndexInternalID) Reset(in uint64) {
+	binary.BigEndian.PutUint64(id, in)
+}
+
 type TermFieldDoc struct {
 	Term    string
 	ID      IndexInternalID

--- a/index.go
+++ b/index.go
@@ -15,10 +15,8 @@
 package index
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
-	"fmt"
 	"reflect"
 )
 
@@ -221,15 +219,19 @@ func (id IndexInternalID) Equals(other IndexInternalID) bool {
 
 // Compare compares two IndexInternalID values, inherently comparing the encoded uint64 values.
 func (id IndexInternalID) Compare(other IndexInternalID) int {
-	return bytes.Compare(id, other)
+	idVal := id.Value()
+	otherVal := other.Value()
+	if idVal < otherVal {
+		return -1
+	} else if idVal > otherVal {
+		return 1
+	}
+	return 0
 }
 
 // Value returns the uint64 value encoded in the IndexInternalID.
-func (id IndexInternalID) Value() (uint64, error) {
-	if len(id) != 8 {
-		return 0, fmt.Errorf("wrong len for IndexInternalID: %q", id)
-	}
-	return binary.BigEndian.Uint64(id), nil
+func (id IndexInternalID) Value() uint64 {
+	return binary.BigEndian.Uint64(id)
 }
 
 type TermFieldDoc struct {


### PR DESCRIPTION
- Remove redundant error from `Value` API.
- Add a `SetValue` method for `IndexInternalID` to replace the existing value 
  with a new one.