### PR TITLE
perf: TermFieldDoc — add NormByte field; targeted Reset writes

### DIFF
--- a/freq_test.go
+++ b/freq_test.go
@@ -132,3 +132,27 @@ func TestTokenFrequenciesMergeAllLeftEmpty(t *testing.T) {
 		t.Errorf("expected %#v, got %#v", expectedResult, tf1)
 	}
 }
+
+func TestTermFieldDocResetClearsNormByte(t *testing.T) {
+	tfd := &TermFieldDoc{
+		Term:     "beer",
+		Freq:     7,
+		Norm:     0.5,
+		NormByte: 42,
+		ID:       IndexInternalID("abc"),
+	}
+	tfd.Reset()
+	if tfd.NormByte != 0 {
+		t.Errorf("expected NormByte=0 after Reset, got %d", tfd.NormByte)
+	}
+	if tfd.Freq != 0 {
+		t.Errorf("expected Freq=0 after Reset, got %d", tfd.Freq)
+	}
+	if tfd.Term != "" {
+		t.Errorf("expected Term=\"\" after Reset, got %q", tfd.Term)
+	}
+	// ID and Vectors backing arrays should be preserved (zero-length, not nil)
+	if tfd.ID == nil {
+		t.Error("expected ID backing array preserved after Reset")
+	}
+}

--- a/index.go
+++ b/index.go
@@ -235,11 +235,12 @@ func (id IndexInternalID) SetValue(in uint64) {
 }
 
 type TermFieldDoc struct {
-	Term    string
-	ID      IndexInternalID
-	Freq    uint64
-	Norm    float64
-	Vectors []*TermFieldVector
+	Term     string
+	ID       IndexInternalID
+	Freq     uint64
+	Norm     float64
+	NormByte uint8 // raw SmallFloat byte from norm column (§20); 0 = not available
+	Vectors  []*TermFieldVector
 }
 
 func (tfd *TermFieldDoc) Size() int {
@@ -255,12 +256,15 @@ func (tfd *TermFieldDoc) Size() int {
 
 // Reset allows an already allocated TermFieldDoc to be reused
 func (tfd *TermFieldDoc) Reset() *TermFieldDoc {
-	// remember the []byte used for the ID
+	// Save backing arrays for reuse — restored below.
 	id := tfd.ID
 	vectors := tfd.Vectors
-	// idiom to copy over from empty TermFieldDoc (0 allocations)
-	*tfd = TermFieldDoc{}
-	// reuse the []byte already allocated (and reset len to 0)
+	// Zero only the fields not being restored (avoids a full-struct duffzero).
+	tfd.Term = ""
+	tfd.Freq = 0
+	tfd.Norm = 0
+	tfd.NormByte = 0
+	// Restore reusable allocations.
 	tfd.ID = id[:0]
 	tfd.Vectors = vectors[:0]
 	return tfd


### PR DESCRIPTION
## Overview

Companion to blevesearch/zapx#438 and blevesearch/bleve#2383 (the "perf-gar" WAND/MAXSCORE effort).

Adds a `NormByte uint8` field to `TermFieldDoc` to carry the raw SmallFloat norm byte from the zapx v18 norm column reader (§20) to the BM25 impact table scorer (§25) in bleve, avoiding a norm re-decode at score time. Also narrows `Reset` to targeted field writes.

Both companion PRs pin this change as a pseudo-version; this needs to land and be tagged before those can move off branch builds.