### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on:
     - master
   pull_request:
 name: Tests
+permissions:
+  contents: read
 jobs:
   test:
     strategy:
@@ -13,11 +15,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Test
       run: |
         go version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x, 1.25.x]
+        go-version: [1.24.x, 1.25.x, 1.26.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Part of a security review of GitHub Actions configurations across the blevesearch public repos.

- Add a least-privilege `permissions: contents: read` block to every workflow (the default token needs no write access here).
- Upgrade deprecated action versions and pin all actions to full commit SHAs, so the CI code cannot change underneath us:
  - `actions/checkout` → v7.0.1
  - `actions/setup-go` → v7.0.0

No changes to what is built or tested.